### PR TITLE
chore: modernize manifest, license field, and controller style

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ui5-messagebox-sequencer-dmo",
   "version": "1.0.0",
   "description": "Minimalistic example for sequencing Popups",
-  "license": "SEE LICENSE IN LICENSE.txt",
+  "license": "Unlicense",
   "scripts": {
     "start": "ui5 serve --open index.html",
     "test": "ui5 serve --open test/testsuite.qunit.html"

--- a/webapp/App.controller.js
+++ b/webapp/App.controller.js
@@ -6,23 +6,16 @@ sap.ui.define(
   function (Controller, MessageBoxSequencer) {
     "use strict";
     return Controller.extend("Demo.App", {
-      onInit: function () {
+      onInit() {
         this._messageBoxSequencer = new MessageBoxSequencer()
       },
 
       onButton() {
-        let value;
-        for (let i = 0; i < 5; ++i) {
-          value = this.byId(`input${i}`).getValue()
-          if (!value || typeof value !== 'string') {
-            continue;
-          }
-          this._webSocketHandler(value)
-        }
-      },
-
-      _webSocketHandler(text) {
-        this._messageBoxSequencer.handleMessage(text)
+        this.byId("inputBox").getItems()
+          .filter((item) => item.isA("sap.m.Input"))
+          .map((input) => input.getValue())
+          .filter((value) => value && typeof value === "string")
+          .forEach((value) => this._messageBoxSequencer.handleMessage(value))
       }
     });
   }

--- a/webapp/App.view.xml
+++ b/webapp/App.view.xml
@@ -20,7 +20,7 @@
 				</l:BlockLayoutRow>
 				<l:BlockLayoutRow>
 					<l:BlockLayoutCell>
-						<VBox class="sapUiSmallMarginBottom" alignItems="Stretch">
+						<VBox id="inputBox" class="sapUiSmallMarginBottom" alignItems="Stretch">
 							<Input id="input0" value="This is some test text, number 1" class="sapUiTinyMarginBottom" />
 							<Input id="input1" value="This is some test text, number 2" class="sapUiTinyMarginBottom" />
 							<Input id="input2" value="This is some test text, number 3" class="sapUiTinyMarginBottom" />

--- a/webapp/manifest.json
+++ b/webapp/manifest.json
@@ -1,11 +1,19 @@
 {
-	"_version": "2.0.0",
+	"_version": "2.6.0",
 	"sap.app": {
 		"id": "Demo",
 		"type": "application",
 		"title": "MessageBox Sequencer Demo",
 		"applicationVersion": {
 			"version": "1.0.0"
+		}
+	},
+	"sap.ui": {
+		"technology": "UI5",
+		"deviceTypes": {
+			"desktop": true,
+			"tablet": true,
+			"phone": true
 		}
 	},
 	"sap.ui5": {
@@ -16,6 +24,10 @@
 				"sap.ui.core": {},
 				"sap.ui.layout": {}
 			}
+		},
+		"contentDensities": {
+			"compact": true,
+			"cozy": true
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Bumped `manifest.json` `_version` from `2.0.0` to `2.6.0` — the current descriptor version supported by OpenUI5 1.146 (per the live SAP docs). Added the now-required `sap.ui` and `sap.ui5.contentDensities` blocks so manifest validation passes.
- Set `package.json` `license` to SPDX `"Unlicense"` (matches the repo's LICENSE content; SPDX-valid).
- `App.controller.js`: aligned `onInit` to ES6 method shorthand, replaced the fixed-index `byId(\`input${i}\`)` loop with an aggregation walk over a newly-id'd `inputBox` VBox, and inlined the single-line `_webSocketHandler` wrapper.
- `App.view.xml`: added `id="inputBox"` to the VBox hosting the inputs (needed by the controller's aggregation walk).

## Verification
- `run_ui5_linter` on the whole project → 0 findings.
- `run_manifest_validation` on `webapp/manifest.json` → `isValid: true`.

## Test plan
- [ ] `npm start` — app loads, five inputs and the "Start Demo" button render
- [ ] Clicking "Start Demo" shows five MessageBoxes sequentially (FIFO), same as before
- [ ] Clearing some inputs before pressing the button skips the empty ones
- [ ] `npm test` — QUnit suite still green

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>